### PR TITLE
feat: Update ComfyUI integration to use FormData

### DIFF
--- a/videogen.ai/src/app/api/comfyui/route.ts
+++ b/videogen.ai/src/app/api/comfyui/route.ts
@@ -2,52 +2,70 @@ import { NextRequest, NextResponse } from 'next/server';
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
+    // The incoming request body is already a ReadableStream of FormData.
+    // We will pass it directly to the fetch call to ComfyUI.
 
     const comfyUIApiUrl = process.env.COMFYUI_API_URL || 'http://127.0.0.1:3000/generate';
 
     // Determine Accept header for ComfyUI request based on frontend's Accept header
-    let acceptHeader = 'application/json'; // Default
+    // This part remains important if the client can request different types of content.
+    // For now, it's usually application/octet-stream for the generated image/video.
+    let acceptHeader = 'application/octet-stream'; // Default, as per OpenAPI spec for success
     const clientAcceptHeader = request.headers.get('accept');
-    if (clientAcceptHeader && (clientAcceptHeader.includes('application/octet-stream') || clientAcceptHeader.includes('image/'))) {
-      acceptHeader = 'application/octet-stream';
+    if (clientAcceptHeader && 
+        (clientAcceptHeader.includes('application/octet-stream') || 
+         clientAcceptHeader.includes('image/*') || 
+         clientAcceptHeader.includes('video/*'))) {
+      acceptHeader = clientAcceptHeader; // Or be more specific if needed
     }
-
+    
+    // When passing request.body directly or a FormData object,
+    // fetch will automatically set the Content-Type header with the correct boundary.
+    // So, DO NOT explicitly set 'Content-Type': 'multipart/form-data' here.
     const comfyUIResponse = await fetch(comfyUIApiUrl, {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/json',
-        'Accept': acceptHeader,
+        // 'Content-Type' will be set by fetch when body is FormData or a stream.
+        'Accept': acceptHeader, 
+        // Potentially pass through other relevant headers from the original request if needed
+        // e.g., 'Authorization' if that was a requirement. For now, keeping it simple.
       },
-      body: JSON.stringify(body),
-      // IMPORTANT: For Next.js Edge/Node.js environments, if you're dealing with large files,
-      // you might need to investigate streaming options for the request body as well,
-      // but for typical JSON payloads, this is fine.
+      body: request.body, // Pass the readable stream directly
+      // For Node.js versions < 18, you might need `duplex: 'half'` here if using streams.
+      // Next.js 13+ edge runtime supports this, serverless functions might vary.
+      // If request.body passthrough causes issues, an alternative is:
+      // const formData = await request.formData();
+      // body: formData,
     });
 
     const responseContentType = comfyUIResponse.headers.get('Content-Type');
 
-    if (responseContentType && responseContentType.includes('application/octet-stream')) {
-      // For binary data like images, clone the response and return it.
-      // This ensures headers like Content-Type, Content-Disposition are passed through.
-      return new NextResponse(comfyUIResponse.body, {
-        status: comfyUIResponse.status,
-        statusText: comfyUIResponse.statusText,
-        headers: comfyUIResponse.headers, // Pass through all headers from ComfyUI
-      });
-    } else if (responseContentType && responseContentType.includes('application/json')) {
-      // For JSON responses
-      const responseData = await comfyUIResponse.json();
-      return NextResponse.json(responseData, { status: comfyUIResponse.status });
+    if (comfyUIResponse.ok) {
+      if (responseContentType && (responseContentType.includes('application/octet-stream') || responseContentType.startsWith('image/') || responseContentType.startsWith('video/'))) {
+        // For binary data like images/videos, clone the response and return it.
+        return new NextResponse(comfyUIResponse.body, {
+          status: comfyUIResponse.status,
+          statusText: comfyUIResponse.statusText,
+          headers: comfyUIResponse.headers, // Pass through all headers from ComfyUI
+        });
+      } else {
+        // If ComfyUI returns an OK response but not an octet-stream (e.g. JSON success message)
+        // This case might need adjustment based on actual ComfyUI behavior for non-image success.
+        const responseData = await comfyUIResponse.json(); // Assuming it might be JSON
+        return NextResponse.json(responseData, { status: comfyUIResponse.status });
+      }
     } else {
-      // For other response types, attempt to return as text.
-      // Or handle as an error, depending on expected behavior.
-      const responseText = await comfyUIResponse.text();
-      return new NextResponse(responseText, {
-        status: comfyUIResponse.status,
-        statusText: comfyUIResponse.statusText,
-        headers: { 'Content-Type': responseContentType || 'text/plain' },
-      });
+      // Handle non-OK responses (errors)
+      // Try to parse as JSON, as error responses in the OpenAPI spec are JSON
+      let errorData;
+      try {
+        errorData = await comfyUIResponse.json();
+      } catch (e) {
+        // If error response isn't JSON, read as text
+        const errorText = await comfyUIResponse.text();
+        errorData = { error: errorText || comfyUIResponse.statusText };
+      }
+      return NextResponse.json(errorData, { status: comfyUIResponse.status });
     }
 
   } catch (error) {


### PR DESCRIPTION
This commit refactors the ComfyUI integration to send `multipart/form-data` from the frontend to the backend proxy, and then to the ComfyUI service. This aligns with the provided OpenAPI specification for the ComfyUI/BentoML endpoint, which requires file uploads (`reference_image`, `video`) and a `Prompt`.

Changes include:

Backend Proxy (`/api/comfyui/route.ts`):
- Modified to accept `multipart/form-data` requests.
- Streams the request body directly to the ComfyUI service, letting `fetch` handle `Content-Type` and boundaries.
- Enhanced error and response handling for `multipart/form-data`.

Frontend (`/app/generate/page.tsx`):
- `handleGenerate` now constructs a `FormData` object.
- `imageFile` (as `reference_image`) and `videoFile` (as `video`) are included as files in the FormData and are now mandatory.
- The `Prompt` sent in FormData is a combination of the selected `artStyle` and your main prompt text.
- The `targetPlatform` selection field is disabled in the UI.
- UI labels, validation, and button states updated to reflect mandatory file inputs and other changes.
- Existing file type/size validation remains active.