### PR TITLE
fix: Add duplex:'half' to fetch in ComfyUI proxy

### DIFF
--- a/videogen.ai/src/app/api/comfyui/route.ts
+++ b/videogen.ai/src/app/api/comfyui/route.ts
@@ -31,6 +31,7 @@ export async function POST(request: NextRequest) {
         // e.g., 'Authorization' if that was a requirement. For now, keeping it simple.
       },
       body: request.body, // Pass the readable stream directly
+      duplex: 'half', // Add this line
       // For Node.js versions < 18, you might need `duplex: 'half'` here if using streams.
       // Next.js 13+ edge runtime supports this, serverless functions might vary.
       // If request.body passthrough causes issues, an alternative is:


### PR DESCRIPTION
Addresses a TypeError: "RequestInit: duplex option is required when sending a body." This error occurred when the Next.js API route `/api/comfyui` streamed the incoming multipart/form-data request body to the ComfyUI backend using `fetch`.

The `duplex: 'half'` option is now added to the `fetch` call within `videogen.ai/src/app/api/comfyui/route.ts`, which is necessary in some Node.js environments when streaming request bodies.