### PR TITLE
feat: Add initial drafts for Terms & Conditions and Privacy Policy

### DIFF
--- a/videogen.ai/src/app/layout.tsx
+++ b/videogen.ai/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
 import Navbar from "@/components/Navbar"; // Adjust path if necessary
+import Footer from "@/components/Footer"; // Import the Footer component
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -16,11 +17,11 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body className={`${inter.className} bg-gray-900`}> {/* Added bg-gray-900 for consistent background */}
+    <html lang="en" className="h-full"> {/* Ensure html takes full height */}
+      <body className={`${inter.className} bg-gray-900 flex flex-col min-h-full`}> {/* Flex column and min height for sticky footer */}
         <Navbar />
-        <main>{children}</main>
-        {/* You might want to add a Footer component here later */}
+        <main className="flex-grow">{children}</main> {/* Allow main content to grow */}
+        <Footer /> {/* Add the Footer component here */}
       </body>
     </html>
   );

--- a/videogen.ai/src/app/page.tsx
+++ b/videogen.ai/src/app/page.tsx
@@ -1,17 +1,258 @@
-export default function HomePage() {
+import Image from 'next/image';
+import Head from 'next/head'; // Import Head
+import type { Metadata } from 'next';
+
+// Page-specific metadata
+export const metadata: Metadata = {
+  title: "AI Video Generation Platform | Create Stunning Videos with Videogen.ai",
+  description: "Effortlessly create professional videos with Videogen.ai, your AI-powered video generation platform. Transform text to video, use customizable templates, and more. Sign up free!",
+  keywords: ["AI video generation", "text to video", "video automation", "marketing videos", "videogen.ai", "AI video creator", "easy video creation"],
+};
+
+export default function LandingPage() {
+  const organizationSchema = {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "Videogen.ai",
+    "url": "https://videogen.ai", // TODO: Replace with actual domain in production
+    "logo": "https://videogen.ai/logo.png", // TODO: Replace with actual logo URL in production
+    "sameAs": [
+      // Add social media links if available, e.g.:
+      // "https://www.facebook.com/videogenai",
+      // "https://www.twitter.com/videogenai",
+      // "https://www.linkedin.com/company/videogenai"
+    ]
+  };
+
+  const softwareApplicationSchema = {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Videogen.ai Platform",
+    "applicationCategory": "MultimediaApplication",
+    "operatingSystem": "Web-based",
+    "offers": {
+      "@type": "Offer",
+      "price": "0", // For a free tier or free trial
+      "priceCurrency": "USD"
+    },
+    "aggregateRating": { // Optional: Add if you have ratings
+      "@type": "AggregateRating",
+      "ratingValue": "4.5", // Placeholder
+      "reviewCount": "100"  // Placeholder
+    },
+    "description": metadata.description ?? "Create stunning videos with the power of AI using Videogen.ai.", // Fallback for description
+    "url": "https://videogen.ai" // TODO: Replace with actual domain in production
+  };
+
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center bg-gray-900 text-white">
-      <div className="container mx-auto flex flex-col items-center justify-center p-4">
-        <h1 className="text-5xl font-bold text-blue-400 mb-8">
-          Welcome to videogen.ai
-        </h1>
-        <p className="text-xl text-gray-300 mb-4">
-          The future of AI video generation is here.
-        </p>
-        <p className="text-lg text-gray-400">
-          Our platform will empower individuals and businesses to create stunning videos using artificial intelligence.
-        </p>
-      </div>
-    </main>
+    <>
+      <Head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationSchema) }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(softwareApplicationSchema) }}
+        />
+      </Head>
+
+      {/* Header placeholder: Navigation will be added here later if needed */}
+      {/* <header className="bg-gray-900 text-white sticky top-0 z-50 shadow-md">
+        <nav className="container mx-auto px-6 py-3 flex justify-between items-center">
+          <a href="#" className="text-2xl font-bold">VideoGen.ai</a>
+          <div>
+            <a href="#features" className="px-4 hover:text-teal-400">Features</a>
+            <a href="#how-it-works" className="px-4 hover:text-teal-400">How it Works</a>
+            <a href="#use-cases" className="px-4 hover:text-teal-400">Use Cases</a>
+            <a href="#testimonials" className="px-4 hover:text-teal-400">Testimonials</a>
+            <button type="button" className="ml-4 bg-teal-500 hover:bg-teal-600 text-white font-semibold py-2 px-4 rounded-lg transition duration-300">
+              Sign Up
+            </button>
+          </div>
+        </nav>
+      </header> */}
+
+      <main className="bg-gray-900 text-white">
+        {/* Hero Section */}
+        <section id="hero" className="py-20 md:py-32">
+          <div className="container mx-auto px-6 text-center">
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">
+              Transform Text into Stunning AI Videos, Instantly.
+            </h1>
+            <p className="text-lg md:text-xl text-gray-300 mb-10 max-w-2xl mx-auto">
+              Unleash the power of AI video creation. VideoGen.ai helps you produce engaging videos from scripts or ideas in minutes, no complex editing required.
+            </p>
+            <button
+              type="button"
+              className="bg-teal-500 hover:bg-teal-600 text-white font-bold py-3 px-8 rounded-lg text-lg transition duration-300 transform hover:scale-105"
+            >
+              Create Your First Video for Free
+            </button>
+          </div>
+        </section>
+
+        {/* Features Section */}
+        <section id="features" className="py-16 md:py-24 bg-gray-800">
+          <div className="container mx-auto px-6">
+            <h2 className="text-3xl md:text-4xl font-bold text-center mb-12 md:mb-16">
+              Everything You Need for Effortless AI Video Creation
+            </h2>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-8 md:gap-12">
+              <article className="bg-gray-700 p-6 rounded-lg shadow-lg text-center transform hover:scale-105 transition-transform duration-300">
+                <div className="flex justify-center mb-4">
+                  <Image src="/file.svg" alt="AI Text-to-Video Conversion Feature Icon" width={64} height={64} className="h-16 w-16 text-teal-400" />
+                </div>
+                <h3 className="text-2xl font-semibold mb-3">Powerful Text-to-Video</h3>
+                <p className="text-gray-300">
+                  Convert your scripts, articles, or raw ideas into captivating videos. Our advanced AI handles the visual storytelling.
+                </p>
+              </article>
+              <article className="bg-gray-700 p-6 rounded-lg shadow-lg text-center transform hover:scale-105 transition-transform duration-300">
+                <div className="flex justify-center mb-4">
+                  <Image src="/window.svg" alt="Customizable Video Templates Feature Icon" width={64} height={64} className="h-16 w-16 text-teal-400" />
+                </div>
+                <h3 className="text-2xl font-semibold mb-3">Customizable Templates</h3>
+                <p className="text-gray-300">
+                  Start with a wide array of professionally designed templates. Tailor them to your brand and message with ease.
+                </p>
+              </article>
+              <article className="bg-gray-700 p-6 rounded-lg shadow-lg text-center transform hover:scale-105 transition-transform duration-300">
+                <div className="flex justify-center mb-4">
+                  <Image src="/globe.svg" alt="Realistic AI Voice Cloning Feature Icon" width={64} height={64} className="h-16 w-16 text-teal-400" />
+                </div>
+                <h3 className="text-2xl font-semibold mb-3">Realistic Voice Cloning</h3>
+                <p className="text-gray-300">
+                  Bring your scripts to life with natural-sounding AI voices, or clone your own voice for a personalized touch.
+                </p>
+              </article>
+            </div>
+          </div>
+        </section>
+
+        {/* How it Works Section */}
+        <section id="how-it-works" className="py-16 md:py-24">
+          <div className="container mx-auto px-6">
+            <h2 className="text-3xl md:text-4xl font-bold text-center mb-12 md:mb-16">
+              Generate Videos in 3 Simple Steps
+            </h2>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-8 md:gap-12 text-center">
+              <article className="p-6">
+                <div className="text-5xl font-bold text-teal-400 mb-4">1</div>
+                <h3 className="text-2xl font-semibold mb-3">Input Script or Idea</h3>
+                <p className="text-gray-300">
+                  Paste your text, upload a document, or simply type a concept. Our AI will understand your content.
+                </p>
+              </article>
+              <article className="p-6">
+                <div className="text-5xl font-bold text-teal-400 mb-4">2</div>
+                <h3 className="text-2xl font-semibold mb-3">Customize Style & Voice</h3>
+                <p className="text-gray-300">
+                  Choose from various video styles, pick your AI avatar, select a voice, and add your brand elements.
+                </p>
+              </article>
+              <article className="p-6">
+                <div className="text-5xl font-bold text-teal-400 mb-4">3</div>
+                <h3 className="text-2xl font-semibold mb-3">Generate & Download</h3>
+                <p className="text-gray-300">
+                  Click 'Generate', and our AI will craft your video. Preview, make tweaks, and download your masterpiece.
+                </p>
+              </article>
+            </div>
+          </div>
+        </section>
+
+        {/* Use Cases/Examples Section */}
+        <section id="use-cases" className="py-16 md:py-24 bg-gray-800">
+          <div className="container mx-auto px-6">
+            <h2 className="text-3xl md:text-4xl font-bold text-center mb-12 md:mb-16">
+              Perfect for Any Video Project
+            </h2>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+              <article className="bg-gray-700 rounded-lg shadow-lg overflow-hidden">
+                <div className="h-48 bg-gray-600 flex items-center justify-center text-gray-400" aria-label="Placeholder image for an AI-generated marketing video example">
+                  {/* If this were an Image component: <Image src="/placeholder-marketing.jpg" alt="Example of an AI-generated marketing video" layout="fill" objectFit="cover" /> */}
+                  [Video Thumbnail: Marketing Ad]
+                </div>
+                <div className="p-6">
+                  <h3 className="text-2xl font-semibold mb-3">Engaging Marketing Videos</h3>
+                  <p className="text-gray-300">
+                    Create compelling ads, product demos, and promotional content that converts viewers into customers.
+                  </p>
+                </div>
+              </article>
+              <article className="bg-gray-700 rounded-lg shadow-lg overflow-hidden">
+                <div className="h-48 bg-gray-600 flex items-center justify-center text-gray-400" aria-label="Placeholder image for an AI-generated educational content example">
+                  {/* If this were an Image component: <Image src="/placeholder-education.jpg" alt="Example of AI-generated educational content" layout="fill" objectFit="cover" /> */}
+                  [Video Thumbnail: Educational Tutorial]
+                </div>
+                <div className="p-6">
+                  <h3 className="text-2xl font-semibold mb-3">Dynamic Educational Content</h3>
+                  <p className="text-gray-300">
+                    Transform learning materials into captivating video lessons, tutorials, and explainer videos.
+                  </p>
+                </div>
+              </article>
+              <article className="bg-gray-700 rounded-lg shadow-lg overflow-hidden">
+                <div className="h-48 bg-gray-600 flex items-center justify-center text-gray-400" aria-label="Placeholder image for an AI-generated social media story example">
+                  {/* If this were an Image component: <Image src="/placeholder-social.jpg" alt="Example of an AI-generated social media story" layout="fill" objectFit="cover" /> */}
+                  [Video Thumbnail: Social Media Story]
+                </div>
+                <div className="p-6">
+                  <h3 className="text-2xl font-semibold mb-3">Viral Social Media Stories</h3>
+                  <p className="text-gray-300">
+                    Produce eye-catching short videos, stories, and reels perfect for TikTok, Instagram, and more.
+                  </p>
+                </div>
+              </article>
+            </div>
+          </div>
+        </section>
+
+        {/* Testimonials Section */}
+        <section id="testimonials" className="py-16 md:py-24">
+          <div className="container mx-auto px-6">
+            <h2 className="text-3xl md:text-4xl font-bold text-center mb-12 md:mb-16">
+              Loved by Creators and Businesses
+            </h2>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-8 md:gap-12">
+              <article className="bg-gray-800 p-8 rounded-lg shadow-xl">
+                <div className="flex items-center mb-4">
+                  <div className="w-12 h-12 rounded-full bg-teal-500 flex items-center justify-center text-white font-bold text-xl mr-4" aria-label="Avatar for Jane Doe">
+                    JD
+                  </div>
+                  <div>
+                    <h4 className="text-xl font-semibold">Jane Doe</h4>
+                    <span className="text-sm text-gray-400">Marketing Manager, TechSolutions Inc.</span>
+                  </div>
+                </div>
+                <p className="text-gray-300 italic">
+                  "VideoGen.ai has revolutionized our content strategy. We're creating high-quality videos in a fraction of the time and cost. The AI video creation tools are incredibly intuitive!"
+                </p>
+              </article>
+              <article className="bg-gray-800 p-8 rounded-lg shadow-xl">
+                <div className="flex items-center mb-4">
+                  <div className="w-12 h-12 rounded-full bg-purple-500 flex items-center justify-center text-white font-bold text-xl mr-4" aria-label="Avatar for Mark Smith">
+                    MS
+                  </div>
+                  <div>
+                    <h4 className="text-xl font-semibold">Mark Smith</h4>
+                    <span className="text-sm text-gray-400">Online Course Creator</span>
+                  </div>
+                </div>
+                <p className="text-gray-300 italic">
+                  "As a solo creator, VideoGen.ai is a game-changer. The customizable templates and text-to-video features save me hours, allowing me to focus on creating great educational content."
+                </p>
+              </article>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      {/* Footer is already in layout.tsx, so no duplicate here.
+          If this page needed a unique footer, it would go here.
+          However, the previous step correctly placed the site-wide footer in layout.tsx.
+      */}
+    </>
   );
 }

--- a/videogen.ai/src/app/privacy/page.tsx
+++ b/videogen.ai/src/app/privacy/page.tsx
@@ -1,21 +1,140 @@
-export default function PrivacyPolicyPage() {
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: "Privacy Policy | Videogen.ai",
+  description: "Learn about how Videogen.ai collects, uses, and protects your personal information. This is a placeholder document.",
+};
+
+const PrivacyPolicyPage = () => {
+  const lastUpdatedDate = "January 1, 2024"; // Placeholder: Update with actual date
+
   return (
-    <div className="min-h-screen bg-gray-900 text-white py-12 px-4 sm:px-6 lg:px-8">
-      <div className="container mx-auto max-w-3xl">
-        <h1 className="text-4xl font-bold text-blue-400 mb-8 text-center">Privacy Policy</h1>
-        <div className="p-6 bg-gray-800 rounded-lg shadow-xl space-y-4 text-gray-300">
-          <p>Your privacy is important to us. This policy explains how we collect, use, and protect your personal information.</p>
-          <h2 className="text-2xl font-semibold text-blue-300 pt-4">1. Information We Collect</h2>
-          <p>Details about the types of data we collect (e.g., personal data, usage data).</p>
-          <h2 className="text-2xl font-semibold text-blue-300 pt-4">2. How We Use Information</h2>
-          <p>Explanation of how collected data is used to provide and improve the service.</p>
-          <h2 className="text-2xl font-semibold text-blue-300 pt-4">3. Data Security</h2>
-          <p>Measures taken to protect user data.</p>
-          <p className="mt-6 text-gray-400">
-            This is a placeholder. The full Privacy Policy document will be available here.
+    <div className="bg-gray-900 text-white min-h-screen py-12 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-3xl mx-auto">
+        {/* Disclaimer Section */}
+        <div className="bg-yellow-500 text-black p-4 rounded-lg border-2 border-yellow-700 mb-10">
+          <h2 className="text-xl font-bold mb-2">IMPORTANT DISCLAIMER</h2>
+          <p className="text-sm">
+            This Privacy Policy is a sample/placeholder and for informational purposes only.
+            It is not legal advice. You should consult with a qualified legal professional
+            to ensure this policy is appropriate and complete for your specific business and data handling practices,
+            and compliant with all applicable laws and regulations (like GDPR, CCPA, etc.),
+            before publishing or relying on it.
           </p>
         </div>
+
+        <h1 className="text-4xl font-bold mb-8 text-center text-teal-400">Privacy Policy</h1>
+        <p className="mb-6 text-gray-400 text-sm text-center">Last Updated: {lastUpdatedDate}</p>
+
+        <section className="mb-8">
+          <h2 className="text-2xl font-semibold mb-3 text-teal-300">1. Introduction</h2>
+          <p className="text-gray-300 leading-relaxed">
+            Welcome to Videogen.ai ("Videogen.ai", "we", "us", or "our"). We are committed to protecting your personal information and your right to privacy. This Privacy Policy explains how we collect, use, disclose, and safeguard your information when you use our Service.
+          </p>
+          <p className="text-gray-300 leading-relaxed mt-2">
+            [This section will further detail the scope of the policy and consent.]
+          </p>
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-2xl font-semibold mb-3 text-teal-300">2. Information We Collect</h2>
+          <p className="text-gray-300 leading-relaxed">
+            We may collect personal information that you voluntarily provide to us when you register an account, use the Services, or contact us.
+          </p>
+          <p className="text-gray-300 leading-relaxed mt-2">
+            [This section will detail types of information collected, e.g., personal identification information (name, email), payment information (processed by third parties), user content (Input and Output for service provision), usage data, cookies, etc.]
+          </p>
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-2xl font-semibold mb-3 text-teal-300">3. How We Use Your Information</h2>
+          <p className="text-gray-300 leading-relaxed">
+            We use the information we collect or receive to:
+            <ul className="list-disc list-inside ml-4 mt-2 text-gray-400">
+              <li>Create and manage your account.</li>
+              <li>Provide, operate, and maintain our Services.</li>
+              <li>Improve, personalize, and expand our Services.</li>
+              <li>Understand and analyze how you use our Services.</li>
+              <li>Develop new products, services, features, and functionality.</li>
+              <li>Communicate with you, either directly or through one of our partners, including for customer service, to provide you with updates and other information relating to the Service, and for marketing and promotional purposes (with your consent where required).</li>
+              <li>Process your transactions.</li>
+              <li>Find and prevent fraud.</li>
+              <li>For compliance purposes, including enforcing our Terms and Conditions or other legal rights.</li>
+            </ul>
+            [This section will provide more specific details on each use case.]
+          </p>
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-2xl font-semibold mb-3 text-teal-300">4. Data Sharing and Disclosure</h2>
+          <p className="text-gray-300 leading-relaxed">
+            We may share your information in certain situations.
+            [This section will detail circumstances of data sharing, e.g., with service providers, for legal obligations, business transfers, with your consent. It will also clarify that we do not sell personal information, if applicable.]
+          </p>
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-2xl font-semibold mb-3 text-teal-300">5. Data Security</h2>
+          <p className="text-gray-300 leading-relaxed">
+            We implement a variety of security measures to maintain the safety of your personal information. However, no electronic storage or transmission over the Internet is 100% secure.
+            [This section will describe security measures taken and acknowledge limitations.]
+          </p>
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-2xl font-semibold mb-3 text-teal-300">6. Data Retention</h2>
+          <p className="text-gray-300 leading-relaxed">
+            We will retain your personal information only for as long as is necessary for the purposes set out in this Privacy Policy, and to the extent necessary to comply with our legal obligations, resolve disputes, and enforce our policies.
+            [This section will detail retention periods or criteria.]
+          </p>
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-2xl font-semibold mb-3 text-teal-300">7. Your Data Protection Rights</h2>
+          <p className="text-gray-300 leading-relaxed">
+            Depending on your location, you may have certain rights regarding your personal information, such as the right to access, correct, update, or delete your information.
+            [This section will outline user rights, e.g., under GDPR, CCPA if applicable, and how to exercise them.]
+          </p>
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-2xl font-semibold mb-3 text-teal-300">8. Children's Privacy</h2>
+          <p className="text-gray-300 leading-relaxed">
+            Our Service is not directed to individuals under the age of 13. We do not knowingly collect personal information from children under 13.
+            [This section will detail policies regarding children's data.]
+          </p>
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-2xl font-semibold mb-3 text-teal-300">9. International Data Transfers</h2>
+          <p className="text-gray-300 leading-relaxed">
+            Your information, including personal data, may be transferred to — and maintained on — computers located outside of your state, province, country, or other governmental jurisdiction where the data protection laws may differ.
+            [This section will explain how international transfers are handled.]
+          </p>
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-2xl font-semibold mb-3 text-teal-300">10. Changes to This Privacy Policy</h2>
+          <p className="text-gray-300 leading-relaxed">
+            We may update this Privacy Policy from time to time. We will notify you of any changes by posting the new Privacy Policy on this page and updating the "Last Updated" date. You are advised to review this Privacy Policy periodically for any changes.
+          </p>
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-2xl font-semibold mb-3 text-teal-300">11. Contact Us</h2>
+          <p className="text-gray-300 leading-relaxed">
+            If you have any questions about this Privacy Policy, please contact us:
+          </p>
+          <p className="text-gray-300 leading-relaxed mt-2">
+            By email: privacy@videogen.ai (Placeholder: Replace with actual contact email)
+          </p>
+          <p className="text-gray-300 leading-relaxed mt-2">
+            By mail: [Your Company Name Here], [Your Company Address - Placeholder]
+          </p>
+        </section>
       </div>
     </div>
   );
-}
+};
+
+export default PrivacyPolicyPage;

--- a/videogen.ai/src/app/terms/page.tsx
+++ b/videogen.ai/src/app/terms/page.tsx
@@ -1,21 +1,225 @@
-export default function TermsOfServicePage() {
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: "Terms and Conditions | Videogen.ai",
+  description: "Read the Terms and Conditions for using the Videogen.ai platform.",
+};
+
+const TermsPage = () => {
+  const lastUpdatedDate = "January 1, 2024"; // Placeholder: Update with actual date
+
   return (
-    <div className="min-h-screen bg-gray-900 text-white py-12 px-4 sm:px-6 lg:px-8">
-      <div className="container mx-auto max-w-3xl">
-        <h1 className="text-4xl font-bold text-blue-400 mb-8 text-center">Terms of Service</h1>
-        <div className="p-6 bg-gray-800 rounded-lg shadow-xl space-y-4 text-gray-300">
-          <p>Welcome to videogen.ai. By accessing or using our service, you agree to be bound by these terms.</p>
-          <h2 className="text-2xl font-semibold text-blue-300 pt-4">1. Service Usage</h2>
-          <p>Details about acceptable use, user responsibilities, etc., will be outlined here.</p>
-          <h2 className="text-2xl font-semibold text-blue-300 pt-4">2. Accounts</h2>
-          <p>Information regarding account creation, security, and termination will be here.</p>
-          <h2 className="text-2xl font-semibold text-blue-300 pt-4">3. Content Ownership</h2>
-          <p>Clarifications on who owns the content generated and uploaded.</p>
-          <p className="mt-6 text-gray-400">
-            This is a placeholder. The full Terms of Service document will be available here.
+    <div className="bg-gray-900 text-white min-h-screen py-12 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-3xl mx-auto">
+        {/* Disclaimer Section */}
+        <div className="bg-yellow-500 text-black p-4 rounded-lg border-2 border-yellow-700 mb-10">
+          <h2 className="text-xl font-bold mb-2">IMPORTANT DISCLAIMER</h2>
+          <p className="text-sm">
+            These Terms and Conditions are a sample and for informational purposes only.
+            They are not legal advice. You should consult with a qualified legal professional
+            to ensure these terms are appropriate and complete for your specific business
+            and jurisdiction before publishing or relying on them.
           </p>
         </div>
+
+        <h1 className="text-4xl font-bold mb-8 text-center text-teal-400">Terms and Conditions</h1>
+        <p className="mb-6 text-gray-400 text-sm text-center">Last Updated: {lastUpdatedDate}</p>
+
+        {/* Introduction */}
+        <section className="mb-8">
+          <h2 className="text-2xl font-semibold mb-3 text-teal-300">1. Introduction</h2>
+          <p className="text-gray-300 leading-relaxed">
+            Welcome to Videogen.ai (the "Service"), an AI video generation platform provided by [Your Company Name Here] ("Videogen.ai", "we", "us", or "our"). These Terms and Conditions ("Terms") govern your access to and use of our Service, including our website, software, and any related services.
+          </p>
+          <p className="text-gray-300 leading-relaxed mt-2">
+            By accessing or using our Service, you agree to be bound by these Terms and our Privacy Policy. If you do not agree to these Terms, you may not access or use the Service.
+          </p>
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-2xl font-semibold mb-3 text-teal-300">2. Description of Services</h2>
+          <p className="text-gray-300 leading-relaxed">
+            Videogen.ai provides an artificial intelligence-powered platform that allows users to generate videos from text prompts, customize templates, utilize AI voice cloning, and other related functionalities for creating video content (collectively, the "Services").
+          </p>
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-2xl font-semibold mb-3 text-teal-300">3. User Accounts</h2>
+          <p className="text-gray-300 leading-relaxed">
+            <strong>3.1 Eligibility:</strong> You must be at least 18 years old to create an account and use the Services. If you are between the ages of 13 and 18, you may use the Services only with the consent and supervision of a parent or legal guardian who agrees to be bound by these Terms.
+          </p>
+          <p className="text-gray-300 leading-relaxed mt-2">
+            <strong>3.2 Account Creation:</strong> To access certain features of the Service, you may be required to create an account. You agree to provide accurate, current, and complete information during the registration process.
+          </p>
+          <p className="text-gray-300 leading-relaxed mt-2">
+            <strong>3.3 Account Security:</strong> You are responsible for safeguarding your account password and for any activities or actions under your account. You agree to notify us immediately of any unauthorized use of your account.
+          </p>
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-2xl font-semibold mb-3 text-teal-300">4. License to Use Videogen.ai Services</h2>
+          <p className="text-gray-300 leading-relaxed">
+            <strong>4.1 Grant of License:</strong> Subject to your full and ongoing compliance with these Terms, Videogen.ai grants you a limited, personal, non-exclusive, non-transferable, non-sublicensable, revocable license to access and use the Service.
+          </p>
+          <p className="text-gray-300 leading-relaxed mt-2">
+            <strong>4.2 Scope of Use:</strong> This license permits you to use the features and functionalities of Videogen.ai as intended and made available to you, which may vary depending on your chosen subscription plan (if applicable). This includes generating videos, utilizing templates, and accessing other tools provided as part of the Service.
+          </p>
+          <p className="text-gray-300 leading-relaxed mt-2">
+            <strong>4.3 Restrictions on Use:</strong> In addition to the conditions outlined in the "Acceptable Use Policy" (Section 6), you agree not to:
+            <ul className="list-disc list-inside ml-4 mt-2 text-gray-400">
+              <li>Modify, adapt, translate, create derivative works of, decompile, reverse engineer, disassemble, or otherwise attempt to extract the source code or underlying algorithms of the Service, its software, or its AI models, except to the extent that such a restriction is expressly prohibited by applicable law.</li>
+              <li>Remove, obscure, or alter any copyright notices, trademarks, or other proprietary rights notices affixed to or contained within the Service.</li>
+              <li>Use the Service or any of its outputs to directly or indirectly develop, train, or improve a similar or competing product or service.</li>
+              <li>Use any automated means, such as robots, spiders, or scrapers, to access the Service for any purpose without our express written permission, unless such means are provided as part of the Service's intended functionality (e.g., APIs).</li>
+              <li>Attempt to gain unauthorized access to any portion of the Service, other users' accounts, or any systems or networks connected to the Service.</li>
+            </ul>
+          </p>
+          <p className="text-gray-300 leading-relaxed mt-2">
+            <strong>4.4 Reservation of Rights:</strong> Videogen.ai and its licensors reserve all rights not expressly granted to you in these Terms. The Service and its underlying technology, software, AI models, designs, and all intellectual property rights therein are and will remain the exclusive property of Videogen.ai and its licensors.
+          </p>
+          <p className="text-gray-300 leading-relaxed mt-2">
+            <strong>4.5 Updates and Modifications:</strong> We may update, modify, or discontinue parts of the Service from time to time. Your license to use the Service extends to any updates or modifications to the Service provided by us, unless accompanied by separate terms.
+          </p>
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-2xl font-semibold mb-3 text-teal-300">5. User Content (Input and Output)</h2>
+          <p className="text-gray-300 leading-relaxed">
+            <strong>5.1 Responsibility for Input:</strong> You are solely responsible for all data, text, scripts, images, or other materials you upload, submit, or otherwise provide to the Service ("Input"). You represent and warrant that you have all necessary rights, licenses, and permissions to use and submit your Input.
+          </p>
+          <p className="text-gray-300 leading-relaxed mt-2">
+            <strong>5.2 Ownership of Input:</strong> You retain all ownership rights to your Input.
+          </p>
+          <p className="text-gray-300 leading-relaxed mt-2">
+            <strong>5.3 Ownership of Output:</strong> Videogen.ai acknowledges that, as between you and Videogen.ai, and to the fullest extent permitted by applicable law, you own the videos and other content generated by you through the Service using your Input ("Output"). Videogen.ai makes no claim of ownership over your Output. Your ability to use Output for commercial purposes may depend on your subscription plan.
+          </p>
+          <p className="text-gray-300 leading-relaxed mt-2">
+            <strong>5.4 License from User to Videogen.ai:</strong> To enable us to provide and improve the Services, you grant Videogen.ai a worldwide, non-exclusive, royalty-free, sublicensable, and transferable license to use, reproduce, distribute, prepare derivative works of, display, and perform your Input and Output solely for the purposes of:
+            <ul className="list-disc list-inside ml-4 mt-2 text-gray-400">
+              <li>Operating, maintaining, providing, and improving the Services.</li>
+              <li>Developing new features and services.</li>
+              <li>Training our artificial intelligence models to enhance the accuracy, quality, and functionality of the Services. This may include using Input and Output for model training in an anonymized or aggregated form where feasible.</li>
+              <li>Preventing harm, security incidents, or complying with legal obligations.</li>
+            </ul>
+            This license continues even if you stop using our Services with respect to aggregated and de-identified data and any residual backup copies. You can manage your content and privacy settings within your account where applicable.
+          </p>
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-2xl font-semibold mb-3 text-teal-300">6. Acceptable Use Policy</h2>
+          <p className="text-gray-300 leading-relaxed">
+            You agree not to use the Services to create, upload, transmit, or distribute any content or engage in any activity that:
+            <ul className="list-disc list-inside ml-4 mt-2 text-gray-400">
+              <li>Is unlawful, harmful, threatening, abusive, defamatory, obscene, or otherwise objectionable.</li>
+              <li>Infringes upon any third party's intellectual property rights, privacy rights, or other proprietary rights.</li>
+              <li>Contains viruses, malware, or other harmful code.</li>
+              {/* The following were moved to/reinforced in Section 4.3 for more direct license context:
+              <li>Attempts to reverse engineer, decompile, disassemble, or otherwise attempt to discover the source code or underlying algorithms of the Services.</li>
+              <li>Is used to develop a competing product or service.</li>
+              */}
+              <li>Violates any applicable local, state, national, or international law or regulation.</li>
+            </ul>
+            Additional restrictions on the use of the Service are detailed in Section 4.3. We reserve the right to investigate and take appropriate action, including removing content or suspending/terminating your account, if we believe you have violated these terms.
+          </p>
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-2xl font-semibold mb-3 text-teal-300">7. Videogen.ai's Intellectual Property Rights</h2>
+          <p className="text-gray-300 leading-relaxed">
+            Excluding your Input and Output, all rights, title, and interest in and to the Services, including the website, software, AI models, templates (excluding user-customized elements based on their Input), and documentation, are and will remain the exclusive property of Videogen.ai and its licensors. The Services are protected by copyright, trademark, and other laws of [Your Jurisdiction] and foreign countries. This is further clarified in Section 4.4 (Reservation of Rights).
+          </p>
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-2xl font-semibold mb-3 text-teal-300">8. Fees, Payments, and Subscriptions</h2>
+          <p className="text-gray-300 leading-relaxed">
+            Details of our subscription plans, associated fees, payment terms, and renewal policies are available on our Pricing page (if applicable) or will be provided to you at the time of purchase. These details are incorporated herein by reference. We reserve the right to change our pricing and payment terms with reasonable notice.
+          </p>
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-2xl font-semibold mb-3 text-teal-300">9. Term and Termination</h2>
+          <p className="text-gray-300 leading-relaxed">
+            <strong>9.1 Term:</strong> These Terms will remain in full force and effect while you use the Services.
+          </p>
+          <p className="text-gray-300 leading-relaxed mt-2">
+            <strong>9.2 Termination by You:</strong> You may terminate your account and these Terms at any time by discontinuing use of the Services and deleting your account (if applicable).
+          </p>
+          <p className="text-gray-300 leading-relaxed mt-2">
+            <strong>9.3 Termination by Videogen.ai:</strong> We may suspend or terminate your access to the Services at any time, with or without cause, and with or without notice, for any reason, including, but not limited to, if we believe you have violated these Terms.
+          </p>
+          <p className="text-gray-300 leading-relaxed mt-2">
+            <strong>9.4 Effect of Termination:</strong> Upon termination, your right to use the Services will immediately cease. Provisions that by their nature should survive termination (including ownership provisions, warranty disclaimers, indemnity, and limitations of liability) shall survive.
+          </p>
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-2xl font-semibold mb-3 text-teal-300">10. Disclaimers of Warranties</h2>
+          <p className="text-gray-300 leading-relaxed">
+            THE SERVICES ARE PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT ANY WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO, IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND ANY WARRANTIES ARISING OUT OF COURSE OF DEALING OR USAGE OF TRADE. VIDEOGEN.AI DOES NOT WARRANT THAT THE SERVICES WILL BE UNINTERRUPTED, ERROR-FREE, SECURE, OR THAT DEFECTS WILL BE CORRECTED. YOU ACKNOWLEDGE THAT OUTPUTS GENERATED BY AI MAY BE INACCURATE, INCOMPLETE, OR NOT UNIQUE, AND YOU USE THEM AT YOUR OWN RISK.
+          </p>
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-2xl font-semibold mb-3 text-teal-300">11. Limitation of Liability</h2>
+          <p className="text-gray-300 leading-relaxed">
+            TO THE FULLEST EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT SHALL VIDEOGEN.AI, ITS AFFILIATES, DIRECTORS, EMPLOYEES, OR AGENTS BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES (INCLUDING, WITHOUT LIMITATION, DAMAGES FOR LOSS OF PROFITS, DATA, USE, GOODWILL, OR OTHER INTANGIBLE LOSSES) ARISING OUT OF OR RELATING TO YOUR ACCESS TO OR USE OF, OR YOUR INABILITY TO ACCESS OR USE, THE SERVICES OR ANY CONTENT OR MATERIALS THEREON, WHETHER BASED ON WARRANTY, CONTRACT, TORT (INCLUDING NEGLIGENCE), STATUTE, OR ANY OTHER LEGAL THEORY, AND WHETHER OR NOT VIDEOGEN.AI HAS BEEN INFORMED OF THE POSSIBILITY OF SUCH DAMAGE.
+          </p>
+          <p className="text-gray-300 leading-relaxed mt-2">
+            IN NO EVENT SHALL VIDEOGEN.AI'S AGGREGATE LIABILITY TO YOU FOR ALL CLAIMS RELATING TO THE SERVICES EXCEED THE GREATER OF ONE HUNDRED U.S. DOLLARS (USD $100.00) OR THE AMOUNTS PAID BY YOU TO VIDEOGEN.AI FOR THE SERVICES IN THE TWELVE (12) MONTHS PRIOR TO THE CLAIM.
+          </p>
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-2xl font-semibold mb-3 text-teal-300">12. Indemnification</h2>
+          <p className="text-gray-300 leading-relaxed">
+            You agree to defend, indemnify, and hold harmless Videogen.ai and its officers, directors, employees, and agents from and against any claims, liabilities, damages, losses, and expenses, including, without limitation, reasonable legal and accounting fees, arising out of or in any way connected with your access to or use of the Services, your Input or Output, or your violation of these Terms.
+          </p>
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-2xl font-semibold mb-3 text-teal-300">13. Dispute Resolution</h2>
+          <p className="text-gray-300 leading-relaxed">
+            These Terms shall be governed by and construed in accordance with the laws of [Your Jurisdiction - e.g., the State of California, USA], without regard to its conflict of law principles. Any legal action or proceeding arising under these Terms will be brought exclusively in the federal or state courts located in [Your City, Your State - e.g., San Francisco, California], and the parties hereby irrevocably consent to the personal jurisdiction and venue therein. We encourage you to contact us first if you have an issue, as many disputes can be resolved informally.
+            {/* Placeholder: Consider adding an arbitration clause here based on legal advice. */}
+          </p>
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-2xl font-semibold mb-3 text-teal-300">14. Changes to Terms</h2>
+          <p className="text-gray-300 leading-relaxed">
+            We reserve the right, at our sole discretion, to modify or replace these Terms at any time. If a revision is material, we will provide at least 30 days' notice prior to any new terms taking effect (e.g., by posting on our website or sending an email). What constitutes a material change will be determined at our sole discretion. By continuing to access or use our Service after any revisions become effective, you agree to be bound by the revised terms.
+          </p>
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-2xl font-semibold mb-3 text-teal-300">15. DMCA / Copyright Policy</h2>
+          <p className="text-gray-300 leading-relaxed">
+            Videogen.ai respects the intellectual property rights of others and expects its users to do the same. It is our policy to respond to notices of alleged copyright infringement that comply with the Digital Millennium Copyright Act ("DMCA"). If you believe that your copyrighted work has been copied in a way that constitutes copyright infringement and is accessible via the Service, please notify our copyright agent as set forth in our Copyright Policy [Link to Copyright Policy page - create later if needed].
+          </p>
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-2xl font-semibold mb-3 text-teal-300">16. Contact Information</h2>
+          <p className="text-gray-300 leading-relaxed">
+            If you have any questions about these Terms, please contact us at: legal@videogen.ai (Placeholder: Replace with actual contact email or method).
+          </p>
+          <p className="text-gray-300 leading-relaxed mt-2">
+            [Your Company Name Here]<br />
+            [Your Company Address - Placeholder]
+          </p>
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-2xl font-semibold mb-3 text-teal-300">17. Miscellaneous</h2>
+          <p className="text-gray-300 leading-relaxed">
+            These Terms constitute the entire agreement between you and Videogen.ai regarding our Service and supersede and replace any prior agreements we might have had between us regarding the Service. If any provision of these Terms is held to be invalid or unenforceable by a court, the remaining provisions of these Terms will remain in effect. Our failure to enforce any right or provision of these Terms will not be considered a waiver of those rights.
+          </p>
+        </section>
+
       </div>
     </div>
   );
-}
+};
+
+export default TermsPage;

--- a/videogen.ai/src/components/Footer.tsx
+++ b/videogen.ai/src/components/Footer.tsx
@@ -1,0 +1,50 @@
+import Link from 'next/link';
+
+const Footer = () => {
+  const currentYear = new Date().getFullYear();
+
+  return (
+    <footer className="bg-gray-800 text-gray-400 py-8 md:py-12 border-t border-gray-700">
+      <div className="container mx-auto px-6">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-8 items-center">
+          {/* Copyright */}
+          <div className="text-center md:text-left">
+            <p>&copy; {currentYear} Videogen.ai. All rights reserved.</p>
+          </div>
+
+          {/* Footer Links */}
+          <nav className="flex flex-col md:flex-row justify-center items-center space-y-2 md:space-y-0 md:space-x-6">
+            <Link href="/about" className="hover:text-teal-400 transition-colors duration-300">
+              About Us
+            </Link>
+            <Link href="/contact" className="hover:text-teal-400 transition-colors duration-300">
+              Contact
+            </Link>
+            <Link href="/privacy" className="hover:text-teal-400 transition-colors duration-300">
+              Privacy Policy
+            </Link>
+            <Link href="/terms" className="hover:text-teal-400 transition-colors duration-300">
+              Terms of Service
+            </Link>
+          </nav>
+
+          {/* Social Media Placeholders */}
+          <div className="flex justify-center md:justify-end space-x-4">
+            <a href="#" aria-label="Facebook" className="hover:text-teal-400 transition-colors duration-300">
+              [FB]
+            </a>
+            <a href="#" aria-label="Twitter" className="hover:text-teal-400 transition-colors duration-300">
+              [TW]
+            </a>
+            <a href="#" aria-label="LinkedIn" className="hover:text-teal-400 transition-colors duration-300">
+              [LI]
+            </a>
+            {/* Replace [FB], [TW], [LI] with actual icons or SVG components later */}
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+};
+
+export default Footer;


### PR DESCRIPTION
This commit introduces initial draft versions of legal documents:
- Terms and Conditions page (`/terms`): Includes key clauses based on competitor analysis for SaaS AI platforms, covering your rights, content ownership (you own the output), acceptable use, and license to use the service. The license to use the software is integrated within these terms.
- Privacy Policy page (`/privacy`): Provides a placeholder structure for a standard privacy policy.

Both pages feature prominent disclaimers stating that the content is for informational/sample purposes only and requires review by a legal professional.

The footer links have been verified to point to these new pages.