### PR TITLE
Update default LLM models across API routes

### DIFF
--- a/videogen.ai/src/app/api/vision-board/chat/ollama/route.ts
+++ b/videogen.ai/src/app/api/vision-board/chat/ollama/route.ts
@@ -4,7 +4,7 @@ import { NextRequest, NextResponse } from 'next/server';
 // Make sure to set OLLAMA_API_BASE_URL in your .env.local file
 // e.g., OLLAMA_API_BASE_URL="http://localhost:11434"
 const OLLAMA_API_BASE_URL = process.env.OLLAMA_API_BASE_URL;
-const DEFAULT_OLLAMA_MODEL = 'llama2'; // A common default, user might have others
+const DEFAULT_OLLAMA_MODEL = 'qwen3:14b'; // A common default, user might have others
 
 export async function POST(req: NextRequest) {
   if (!OLLAMA_API_BASE_URL) {

--- a/videogen.ai/src/app/api/vision-board/chat/openrouter/route.ts
+++ b/videogen.ai/src/app/api/vision-board/chat/openrouter/route.ts
@@ -6,7 +6,7 @@ const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY;
 const OPENROUTER_API_URL = 'https://openrouter.ai/api/v1/chat/completions';
 
 // You can specify a default model or make it configurable
-const DEFAULT_MODEL = 'mistralai/mistral-7b-instruct';
+const DEFAULT_MODEL = 'deepseek/deepseek-r1-0528:free';
 
 export async function POST(req: NextRequest) {
   if (!OPENROUTER_API_KEY) {

--- a/videogen.ai/src/app/api/vision-board/search/perplexity/route.ts
+++ b/videogen.ai/src/app/api/vision-board/search/perplexity/route.ts
@@ -8,7 +8,7 @@ const PERPLEXITY_API_URL = 'https://api.perplexity.ai/chat/completions';
 // See Perplexity documentation for available models with internet access.
 // 'pplx-7b-online' was an example, but it's not a chat completion model.
 // Using 'sonar-small-online' or 'sonar-medium-online' for search-enabled chat.
-const PERPLEXITY_ONLINE_MODEL = 'sonar-medium-online';
+const PERPLEXITY_ONLINE_MODEL = 'sonar';
 
 export async function POST(req: NextRequest) {
   if (!PERPLEXITY_API_KEY) {


### PR DESCRIPTION
Update default models to newer versions: Ollama to qwen3:14b, OpenRouter to deepseek/deepseek-r1-0528:free, and Perplexity to sonar for improved performance and capabilities.